### PR TITLE
feat: add admin dashboard stats and enrollment trend endpoints

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -24,6 +24,7 @@ import { UserPremiumModule } from './user-premium/user-premium.module';
 import { PaymentsPremiumModule } from './payments-premium/payments-premium.module';
 import { CourseContentsModule } from './course-contents/course-contents.module';
 import { CourseSessionsModule } from './course-sessions/course-sessions.module';
+import { DashboardModule } from './dashboard/dashboard.module';
 
 @Module({
   imports: [
@@ -74,6 +75,7 @@ import { CourseSessionsModule } from './course-sessions/course-sessions.module';
     PaymentsPremiumModule,
     CourseContentsModule,
     CourseSessionsModule,
+    DashboardModule,
   ],
   controllers: [],
   providers: [

--- a/src/dashboard/dashboard.controller.ts
+++ b/src/dashboard/dashboard.controller.ts
@@ -1,0 +1,29 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import JwtAdminAuthenticationGuard from 'src/authentication/guard/jwt-admin-authentication.guard';
+import { DashboardService } from './dashboard.service';
+
+@ApiTags('Admin Dashboard')
+@ApiBearerAuth()
+@Controller('admin/dashboard')
+@UseGuards(JwtAdminAuthenticationGuard)
+export class DashboardController {
+  constructor(private readonly dashboardService: DashboardService) {}
+
+  @ApiOperation({
+    summary:
+      'Overview stats: total courses, users, organizations, completed enrollments',
+  })
+  @Get('stats')
+  getStats() {
+    return this.dashboardService.getStats();
+  }
+
+  @ApiOperation({
+    summary: 'Completed enrollments per day for the last N days',
+  })
+  @Get('enrollment-trend')
+  getEnrollmentTrend(@Query('days') days?: string) {
+    return this.dashboardService.getEnrollmentTrend(days ? +days : 30);
+  }
+}

--- a/src/dashboard/dashboard.module.ts
+++ b/src/dashboard/dashboard.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Course } from 'src/courses/entities/courses.entity';
+import { User } from 'src/users/entities/user.entity';
+import { Organization } from 'src/organizations/entities/organization.entity';
+import { UserCourse } from 'src/user-courses/entities/user-course.entity';
+import { DashboardController } from './dashboard.controller';
+import { DashboardService } from './dashboard.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Course, User, Organization, UserCourse])],
+  controllers: [DashboardController],
+  providers: [DashboardService],
+})
+export class DashboardModule {}

--- a/src/dashboard/dashboard.service.ts
+++ b/src/dashboard/dashboard.service.ts
@@ -1,0 +1,90 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Course } from 'src/courses/entities/courses.entity';
+import { User } from 'src/users/entities/user.entity';
+import { Organization } from 'src/organizations/entities/organization.entity';
+import { UserCourse } from 'src/user-courses/entities/user-course.entity';
+
+export interface DashboardStats {
+  totalCourses: number;
+  totalUsers: number;
+  totalOrganizations: number;
+  totalCompletedEnrollments: number;
+}
+
+export interface EnrollmentTrendPoint {
+  date: string;
+  count: number;
+}
+
+@Injectable()
+export class DashboardService {
+  constructor(
+    @InjectRepository(Course)
+    private readonly courseRepository: Repository<Course>,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+    @InjectRepository(Organization)
+    private readonly organizationRepository: Repository<Organization>,
+    @InjectRepository(UserCourse)
+    private readonly userCourseRepository: Repository<UserCourse>,
+  ) {}
+
+  async getStats(): Promise<DashboardStats> {
+    const [
+      totalCourses,
+      totalUsers,
+      totalOrganizations,
+      totalCompletedEnrollments,
+    ] = await Promise.all([
+      this.courseRepository.count({ where: { deletedAt: null } }),
+      this.userRepository.count({ where: { deletedAt: null } }),
+      this.organizationRepository.count({ where: { deletedAt: null } }),
+      this.userCourseRepository.count({ where: { status: 'completed' } }),
+    ]);
+
+    return {
+      totalCourses,
+      totalUsers,
+      totalOrganizations,
+      totalCompletedEnrollments,
+    };
+  }
+
+  async getEnrollmentTrend(days: number): Promise<EnrollmentTrendPoint[]> {
+    const safedays = Math.min(Math.max(days || 30, 1), 365);
+
+    const rows: { date: string; count: string }[] =
+      await this.userCourseRepository
+        .createQueryBuilder('userCourse')
+        .select('CAST(userCourse.createdAt AS DATE)', 'date')
+        .addSelect('COUNT(*)', 'count')
+        .where('userCourse.status = :status', { status: 'completed' })
+        .andWhere(
+          "userCourse.createdAt >= NOW() - (INTERVAL '1 day' * :days)",
+          {
+            days: safedays,
+          },
+        )
+        .groupBy('CAST(userCourse.createdAt AS DATE)')
+        .orderBy('date', 'ASC')
+        .getRawMany();
+
+    const countByDate = new Map<string, number>();
+    for (const row of rows) {
+      const key = new Date(row.date).toISOString().slice(0, 10);
+      countByDate.set(key, parseInt(row.count, 10));
+    }
+
+    const result: EnrollmentTrendPoint[] = [];
+    const today = new Date();
+    for (let i = safedays - 1; i >= 0; i--) {
+      const d = new Date(today);
+      d.setDate(d.getDate() - i);
+      const key = d.toISOString().slice(0, 10);
+      result.push({ date: key, count: countByDate.get(key) ?? 0 });
+    }
+    return result;
+  }
+}


### PR DESCRIPTION
- GET /admin/dashboard/stats: total courses, users, organizations, and completed enrollments
- GET /admin/dashboard/enrollment-trend: completed enrollments per day for the last N days (default 30), gap-filled with zero counts